### PR TITLE
Newlib compatibility

### DIFF
--- a/ee/src/sjpcm_rpc.c
+++ b/ee/src/sjpcm_rpc.c
@@ -21,7 +21,6 @@
 
 #include <tamtypes.h>
 #include <kernel.h>
-#include <fileio.h>
 #include <sifrpc.h>
 #include <stdarg.h>
 #include <string.h>


### PR DESCRIPTION
fileio.h should no longer be used in the newlib port. isjpcm does not really use it, so this fix was easy ;).